### PR TITLE
fix: index: add support of acorn v7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 "use strict"
 
 const acorn = require("acorn")
-if (acorn.version.indexOf("6.") != 0 || acorn.version.indexOf("6.0.") == 0) {
-  throw new Error(`acorn-private-class-elements requires acorn@^6.1.0, not ${acorn.version}`)
+if (acorn.version.indexOf("6.") != 0 && acorn.version.indexOf("6.0.") == 0 && acorn.version.indexOf("7.") != 0) {
+  throw new Error(`acorn-private-class-elements requires acorn@^6.1.0 or acorn@7.0.0, not ${acorn.version}`)
 }
 const tt = acorn.tokTypes
 const TokenType = acorn.TokenType

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "lint": "eslint -c .eslintrc.json ."
   },
   "peerDependencies": {
-    "acorn": "^6.1.0"
+    "acorn": "^6.1.0 || ^7.0.0"
   },
   "version": "0.1.1",
   "devDependencies": {
-    "acorn": "^6.1.0",
+    "acorn": "^7.0.0",
     "eslint": "^5.13.0",
     "eslint-plugin-node": "^8.0.1"
   },


### PR DESCRIPTION
Add ability to not crash on `acorn` v7 (acornjs/acorn#862)