### PR TITLE
Move mocha from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
   "devDependencies": {
     "acorn": "^6.1.0",
     "eslint": "^5.13.0",
-    "eslint-plugin-node": "^8.0.1"
-  },
-  "dependencies": {
+    "eslint-plugin-node": "^8.0.1",
     "mocha": "^5.2.0"
   }
 }


### PR DESCRIPTION
Mocha is incorrectly listed as a dependency instead of devDependency meaning that projects that use it will include mocha in their packages.