### PR TITLE
Migrate to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 const getPrototype = Object.getPrototypeOf || (o => o.__proto__)
 
@@ -21,7 +21,7 @@ const getAcorn = Parser => {
   return acorn
 }
 
-module.exports = function(Parser) {
+export default function privateClassElements(Parser) {
   // Only load this plugin once.
   if (Parser.prototype.parsePrivateName) {
     return Parser

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-"use strict";
+"use strict"
 
 const getPrototype = Object.getPrototypeOf || (o => o.__proto__)
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "contributors": [
     "Adrian Heine <mail@adrianheine.de>"
   ],
+  "main": "dist/acorn-private-class-elements.js",
+  "module": "dist/acorn-private-class-elements.mjs",
   "engines": {
     "node": ">=4.8.2"
   },
@@ -14,17 +16,19 @@
   },
   "license": "MIT",
   "scripts": {
+    "build": "rollup -c rollup.config.js",
     "test": "mocha",
     "lint": "eslint -c .eslintrc.json ."
   },
   "peerDependencies": {
     "acorn": "^6.1.0 || ^7 || ^8"
   },
-  "version": "0.2.7",
+  "version": "0.2.8",
   "devDependencies": {
     "acorn": "^7.0.0",
     "eslint": "^7",
     "eslint-plugin-node": "^11.0.0",
-    "mocha": "^8"
+    "mocha": "^8",
+    "rollup": "^2.10.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+export default {
+  input: "index.js",
+  output: [
+    {
+      file: "dist/acorn-private-class-elements.js",
+      format: "cjs",
+      sourcemap: true
+    },
+    {
+      file: "dist/acorn-private-class-elements.mjs",
+      format: "es",
+      sourcemap: true
+    }
+  ]
+}


### PR DESCRIPTION
We've recently migrated Chrome DevTools to ESM, and have traditionally
been using acorn as the parser for various features including the
prettifier. In the context of https://crbug.com/1084349 we are looking
into including private fields support in Chrome DevTools via this
plugin, and in order to make that easier with our build system, I've
added support for ESM output here in addition to the CJS output.

Similar change to
https://github.com/acornjs/acorn-private-methods/pull/4.