### PR TITLE
Update AST node names to match ESTree [breaking change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a plugin for [Acorn](http://marijnhaverbeke.nl/acorn/) - a tiny, fast JavaScript parser, written completely in JavaScript.
 
-It provides helpers for implementing support for private class elements. The emitted AST follows [an ESTree proposal](https://github.com/estree/estree/pull/180).
+It provides helpers for implementing support for private class elements. The emitted AST follows the [ESTree experimental Class Features design](https://github.com/estree/estree/blob/master/experimental/class-features.md).
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function(Parser) {
       const node = this.startNode()
       node.name = this.value
       this.next()
-      this.finishNode(node, "PrivateName")
+      this.finishNode(node, "PrivateIdentifier")
       if (this.options.allowReserved == "never") this.checkUnreserved(node)
       return node
     }
@@ -68,7 +68,7 @@ module.exports = function(Parser) {
       if (code === 35) {
         ++this.pos
         const word = this.readWord1()
-        return this.finishToken(this.privateNameToken, word)
+        return this.finishToken(this.privateIdentifierToken, word)
       }
       return super.getTokenFromCode(code)
     }
@@ -117,7 +117,7 @@ module.exports = function(Parser) {
       const branch = this._branch()
       if (!(
         (branch.eat(acorn.tokTypes.dot) || (optionalSupported && branch.eat(acorn.tokTypes.questionDot))) &&
-        branch.type == this.privateNameToken
+        branch.type == this.privateIdentifierToken
       )) {
         return super.parseSubscript.apply(this, arguments)
       }
@@ -132,7 +132,7 @@ module.exports = function(Parser) {
       if (optionalSupported) {
         node.optional = optional
       }
-      if (this.type == this.privateNameToken) {
+      if (this.type == this.privateIdentifierToken) {
         if (base.type == "Super") {
           this.raise(this.start, "Cannot access private element on super")
         }
@@ -153,13 +153,13 @@ module.exports = function(Parser) {
     parseMaybeUnary(refDestructuringErrors, sawUnary) {
       const _return = super.parseMaybeUnary(refDestructuringErrors, sawUnary)
       if (_return.operator == "delete") {
-        if (_return.argument.type == "MemberExpression" && _return.argument.property.type == "PrivateName") {
+        if (_return.argument.type == "MemberExpression" && _return.argument.property.type == "PrivateIdentifier") {
           this.raise(_return.start, "Private elements may not be deleted")
         }
       }
       return _return
     }
   }
-  Parser.prototype.privateNameToken = new acorn.TokenType("privateName")
+  Parser.prototype.privateIdentifierToken = new acorn.TokenType("privateIdentifier")
   return Parser
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "acorn": "^6.1.0 || ^7 || ^8"
   },
-  "version": "0.2.7",
+  "version": "1.0.0",
   "devDependencies": {
     "acorn": "^7.0.0",
     "eslint": "^7",


### PR DESCRIPTION
The ESTree spec for new Class Features ([here](https://github.com/estree/estree/blob/master/experimental/class-features.md)) was standardised in https://github.com/estree/estree/pull/222, merged July 2020, before this package was developed. The naming in this spec changed during its development, resulting in this (and other) acorn class feature packages being out of sync.

This was highlighted in https://github.com/acornjs/acorn-class-fields/issues/15.

This is a breaking change as it changes the names of AST nodes and the implementation properties that represent them. As a result I have bumped the package's major version.

This is the first of ~5 PRs to the following repositories to synchronise things:
- https://github.com/acornjs/acorn-private-class-elements (this one)
- https://github.com/acornjs/acorn-private-methods (depends on this)
- https://github.com/acornjs/acorn-class-fields (depends on this)
- https://github.com/acornjs/acorn-static-class-features (depends on this)
- https://github.com/acornjs/acorn-stage3 (depends on all of the above)